### PR TITLE
Feat: Added Health statistics for Service registry

### DIFF
--- a/src/main/java/pt/ua/deti/es/serviceregistry/web/controllers/HealthController.java
+++ b/src/main/java/pt/ua/deti/es/serviceregistry/web/controllers/HealthController.java
@@ -1,0 +1,26 @@
+package pt.ua.deti.es.serviceregistry.web.controllers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import pt.ua.deti.es.serviceregistry.entities.HealthReport;
+import pt.ua.deti.es.serviceregistry.web.services.HealthService;
+
+@RestController
+@RequestMapping("/health")
+public class HealthController {
+
+    private final HealthService healthService;
+
+    @Autowired
+    public HealthController(HealthService healthService) {
+        this.healthService = healthService;
+    }
+
+    @GetMapping()
+    public HealthReport getHealthStatus() {
+        return healthService.getHealthReport();
+    }
+
+}

--- a/src/main/java/pt/ua/deti/es/serviceregistry/web/services/HealthService.java
+++ b/src/main/java/pt/ua/deti/es/serviceregistry/web/services/HealthService.java
@@ -1,0 +1,13 @@
+package pt.ua.deti.es.serviceregistry.web.services;
+
+import org.springframework.stereotype.Service;
+import pt.ua.deti.es.serviceregistry.entities.HealthReport;
+
+@Service
+public class HealthService {
+
+    public HealthReport getHealthReport() {
+        return new HealthReport(true, null);
+    }
+
+}


### PR DESCRIPTION
### Description:

Added endpoint /health to provide health statistics about the service registry. This endpoint will be used by the AWS load balancer to check if the service should be re-deployed.

### What changed?

* Added /health endpoint to obtain health statistics;
* Added HealthController to add the health endpoint;
* Added HealthService to provide useful methods for the HealthController.

### How was it tested?

Tested manually.

### Documentation

N/A