### PR TITLE
Fix: Service Registry not freeing IDs on the first try when a new service is trying to register itself.

### DIFF
--- a/src/main/java/pt/ua/deti/es/serviceregistry/web/controllers/RegistryController.java
+++ b/src/main/java/pt/ua/deti/es/serviceregistry/web/controllers/RegistryController.java
@@ -9,6 +9,7 @@ import pt.ua.deti.es.serviceregistry.web.entities.RegistrationResponse;
 import pt.ua.deti.es.serviceregistry.web.entities.UnregistrationRequest;
 import pt.ua.deti.es.serviceregistry.web.services.RegistryWebService;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @RestController
@@ -26,10 +27,16 @@ public class RegistryController {
     public RegistrationResponse registerNewComponent(@RequestBody RegistrationRequest registrationRequest) {
 
         ComponentType componentType = registrationRequest.getComponentType();
-        UUID registeredComponentUniqueId = registryWebService.registerComponent(registrationRequest,
-                registryWebService.getUniqueIdForComponent(componentType,
-                        registryWebService.getOccupiedIds(),
-                        registryWebService.hasAvailableIds(componentType, registryWebService.getFilteredRegisteredComponents(componentType))));
+        boolean hasAvailableUniqueIds = registryWebService.hasAvailableIds(componentType, registryWebService.getFilteredRegisteredComponents(componentType));
+        Optional<UUID> componentUniqueId;
+
+        if (!hasAvailableUniqueIds) {
+            componentUniqueId = registryWebService.freeUniqueIdForComponent(componentType);
+        } else {
+            componentUniqueId = registryWebService.getUniqueIdForComponent(componentType, registryWebService.getOccupiedIds());
+        }
+
+        UUID registeredComponentUniqueId = registryWebService.registerComponent(registrationRequest, componentUniqueId);
 
         if (registeredComponentUniqueId != null) {
             return new RegistrationResponse("Service successfully registered.", registeredComponentUniqueId);

--- a/src/test/java/pt/ua/deti/es/serviceregistry/web/services/RegistryWebServiceTest.java
+++ b/src/test/java/pt/ua/deti/es/serviceregistry/web/services/RegistryWebServiceTest.java
@@ -136,35 +136,35 @@ class RegistryWebServiceTest {
     @Test
     void getUniqueIdForComponent() {
 
-        assertThat(registryWebService.getUniqueIdForComponent(ComponentType.CAMERA, new ArrayList<>(), true))
+        assertThat(registryWebService.getUniqueIdForComponent(ComponentType.CAMERA, new ArrayList<>()))
                 .isNotNull()
                 .isNotPresent();
 
-        assertThat(registryWebService.getUniqueIdForComponent(ComponentType.CAMERA, new ArrayList<>(),false))
+        assertThat(registryWebService.getUniqueIdForComponent(ComponentType.CAMERA, new ArrayList<>()))
                 .isNotNull()
                 .isNotPresent();
 
-        assertThat(registryWebService.getUniqueIdForComponent(ComponentType.UI, new ArrayList<>(), true))
+        assertThat(registryWebService.getUniqueIdForComponent(ComponentType.UI, new ArrayList<>()))
                 .isNotNull()
                 .isNotPresent();
 
-        assertThat(registryWebService.getUniqueIdForComponent(ComponentType.UI, new ArrayList<>(),false))
+        assertThat(registryWebService.getUniqueIdForComponent(ComponentType.UI, new ArrayList<>()))
                 .isNotNull()
                 .isNotPresent();
 
-        assertThat(registryWebService.getUniqueIdForComponent(ComponentType.API, new ArrayList<>(), true))
+        assertThat(registryWebService.getUniqueIdForComponent(ComponentType.API, new ArrayList<>()))
                 .isNotNull()
                 .isNotPresent();
 
-        assertThat(registryWebService.getUniqueIdForComponent(ComponentType.API, new ArrayList<>(),false))
+        assertThat(registryWebService.getUniqueIdForComponent(ComponentType.API, new ArrayList<>()))
                 .isNotNull()
                 .isNotPresent();
 
-        assertThat(registryWebService.getUniqueIdForComponent(ComponentType.ALARM, new ArrayList<>(), true))
+        assertThat(registryWebService.getUniqueIdForComponent(ComponentType.ALARM, new ArrayList<>()))
                 .isNotNull()
                 .isNotPresent();
 
-        assertThat(registryWebService.getUniqueIdForComponent(ComponentType.ALARM, new ArrayList<>(),false))
+        assertThat(registryWebService.getUniqueIdForComponent(ComponentType.ALARM, new ArrayList<>()))
                 .isNotNull()
                 .isNotPresent();
 
@@ -218,19 +218,60 @@ class RegistryWebServiceTest {
     }
 
     @Test
-    void freeUniqueIdForComponent() {
+    void freeUniqueIdForComponent_whenDeviceOffline() {
 
         UUID componentUniqueId = UUID.randomUUID();
+
         RegisteredComponentDto registeredComponentDtoStub = new RegisteredComponentDto(
                 componentUniqueId, "", "",
-                ComponentProtocol.HTTP, ComponentType.ALARM, mock(ComponentAddressDto.class),
-                mock(ComponentAvailabilityDto.class));
+                ComponentProtocol.HTTP, ComponentType.CAMERA, mock(ComponentAddressDto.class),
+                new ComponentAvailabilityDto(1L, ComponentAvailability.OFFLINE, 100L));
 
+        when(registeredComponentService.getRegisteredComponents()).thenReturn(List.of(registeredComponentDtoStub));
         when(registeredComponentService.unregisterComponent(componentUniqueId)).thenReturn(true);
 
-        assertThat(registryWebService.freeUniqueIdForComponent(Optional.of(registeredComponentDtoStub)))
+        assertThat(registryWebService.freeUniqueIdForComponent(ComponentType.CAMERA))
                 .isNotNull()
+                .isPresent()
+                .get()
                 .isEqualTo(componentUniqueId);
+
+    }
+
+    @Test
+    void freeUniqueIdForComponent_whenNoDevicesOffline() {
+
+        UUID componentUniqueId = UUID.randomUUID();
+
+        RegisteredComponentDto registeredComponentDtoStub = new RegisteredComponentDto(
+                componentUniqueId, "", "",
+                ComponentProtocol.HTTP, ComponentType.CAMERA, mock(ComponentAddressDto.class),
+                new ComponentAvailabilityDto(1L, ComponentAvailability.ONLINE, 100L));
+
+        when(registeredComponentService.getRegisteredComponents()).thenReturn(List.of(registeredComponentDtoStub));
+
+        assertThat(registryWebService.freeUniqueIdForComponent(ComponentType.CAMERA))
+                .isNotNull()
+                .isNotPresent();
+
+    }
+
+    @Test
+    void freeUniqueIdForComponent_whenUnableToRegister() {
+
+        UUID componentUniqueId = UUID.randomUUID();
+
+        RegisteredComponentDto registeredComponentDtoStub = new RegisteredComponentDto(
+                componentUniqueId, "", "",
+                ComponentProtocol.HTTP, ComponentType.CAMERA, mock(ComponentAddressDto.class),
+                new ComponentAvailabilityDto(1L, ComponentAvailability.OFFLINE, 100L));
+
+        when(registeredComponentService.getRegisteredComponents()).thenReturn(List.of(registeredComponentDtoStub));
+        when(registeredComponentService.unregisterComponent(componentUniqueId)).thenReturn(false);
+
+        assertThat(registryWebService.freeUniqueIdForComponent(ComponentType.CAMERA))
+                .isNotNull()
+                .isNotPresent();
 
     }
 

--- a/src/test/java/pt/ua/deti/es/serviceregistry/web/services/RegistryWebServiceTest.java
+++ b/src/test/java/pt/ua/deti/es/serviceregistry/web/services/RegistryWebServiceTest.java
@@ -218,7 +218,7 @@ class RegistryWebServiceTest {
     }
 
     @Test
-    void freeUniqueIdForComponent_whenDeviceOffline() {
+    void freeUniqueIdForComponentWhenDeviceOffline() {
 
         UUID componentUniqueId = UUID.randomUUID();
 
@@ -239,7 +239,7 @@ class RegistryWebServiceTest {
     }
 
     @Test
-    void freeUniqueIdForComponent_whenNoDevicesOffline() {
+    void freeUniqueIdForComponentWhenNoDevicesOffline() {
 
         UUID componentUniqueId = UUID.randomUUID();
 
@@ -257,7 +257,7 @@ class RegistryWebServiceTest {
     }
 
     @Test
-    void freeUniqueIdForComponent_whenUnableToRegister() {
+    void freeUniqueIdForComponentWhenUnableToRegister() {
 
         UUID componentUniqueId = UUID.randomUUID();
 


### PR DESCRIPTION
### Description:
When a new service tries to register itself in the Service Registry, the Service Registry will attribute a new ID to the new service from a pool of available IDs. However, if the pool doesn't have enough addresses available the Service Registry will try to unregister one of the offline services and use its address in the new service. 
Due to a small bug, we needed to perform the same request 2 times to get a new id from the pool: the first one was to unregister the offline service, and the second one was to associate the freed id with the new service. This behavior is fixed in this PR.

### What changed?

* Fixed the double request bug for the service registration. 

### How was it tested?

* Using Unit tests;

### Documentation

Documentation in Postman.