### PR TITLE
Fix: Fixed Health Report deserialization.

### DIFF
--- a/src/main/java/pt/ua/deti/es/serviceregistry/entities/HealthReport.java
+++ b/src/main/java/pt/ua/deti/es/serviceregistry/entities/HealthReport.java
@@ -1,5 +1,6 @@
 package pt.ua.deti.es.serviceregistry.entities;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Generated;
@@ -9,11 +10,13 @@ import java.util.List;
 
 @Data
 @Generated
-@NoArgsConstructor
 @AllArgsConstructor
+@NoArgsConstructor
 public class HealthReport {
 
+    @JsonProperty("isHealthy")
     private boolean isHealthy;
+    @JsonProperty("additionalProperties")
     private List<?> additionalProperties;
 
 }


### PR DESCRIPTION
### Description:

The health reports provided by other services were not being correctly deserialized by Jackson. This led the Service Registry to always interpret the field "isHealthy" from the received HealthReports as "false" therefore making the services show up as offline even when they were online.

### What changed?

* Added @JsonProperty above fields in HealthReport class.

### How was it tested?

Tested manually and covered by unit tests.

Documentation

https://github.com/ES-22-23/Documentation