### PR TITLE
Fix: Fixed Health Checks for UI components

### DIFF
--- a/src/main/java/pt/ua/deti/es/serviceregistry/schedulers/ComponentsHealthScheduler.java
+++ b/src/main/java/pt/ua/deti/es/serviceregistry/schedulers/ComponentsHealthScheduler.java
@@ -14,6 +14,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.UnknownContentTypeException;
 import pt.ua.deti.es.serviceregistry.data.dto.RegisteredComponentDto;
 import pt.ua.deti.es.serviceregistry.entities.ComponentAvailability;
 import pt.ua.deti.es.serviceregistry.entities.ComponentType;
@@ -59,8 +60,10 @@ public class ComponentsHealthScheduler {
             try {
                 componentHealthReport = restTemplate.exchange(componentHealthEndpoint, HttpMethod.GET, null, HealthReport.class);
             } catch (ResourceAccessException e) {
-                // Ignore Timeout Exception. Already treated in the next if statement.
+                // Ignore Timeout and Failed to Convert to Health Report Exceptions. Already treated in the next if statement.
                 componentHealthReport = null;
+            } catch (UnknownContentTypeException e) {
+                componentHealthReport = new ResponseEntity<>(null, HttpStatus.valueOf(e.getRawStatusCode()));
             }
 
             boolean isComponentHealthy;

--- a/src/main/java/pt/ua/deti/es/serviceregistry/schedulers/ComponentsHealthScheduler.java
+++ b/src/main/java/pt/ua/deti/es/serviceregistry/schedulers/ComponentsHealthScheduler.java
@@ -4,16 +4,21 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
+import pt.ua.deti.es.serviceregistry.data.dto.RegisteredComponentDto;
 import pt.ua.deti.es.serviceregistry.entities.ComponentAvailability;
-import pt.ua.deti.es.serviceregistry.utils.ComponentUtils;
+import pt.ua.deti.es.serviceregistry.entities.ComponentType;
 import pt.ua.deti.es.serviceregistry.entities.HealthReport;
+import pt.ua.deti.es.serviceregistry.utils.ComponentUtils;
 import pt.ua.deti.es.serviceregistry.web.services.RegistryWebService;
 
 import java.time.Duration;
@@ -49,36 +54,49 @@ public class ComponentsHealthScheduler {
 
             String componentHealthEndpoint = componentUtils.buildHealthEndpoint(registeredComponent, false);
 
-            HealthReport componentHealthReport;
+            ResponseEntity<HealthReport> componentHealthReport;
 
             try {
-                componentHealthReport = restTemplate.getForObject(componentHealthEndpoint, HealthReport.class);
-            } catch (RestClientException e) {
-                // Ignore Exception. Already treated in the next if statement.
+                componentHealthReport = restTemplate.exchange(componentHealthEndpoint, HttpMethod.GET, null, HealthReport.class);
+            } catch (ResourceAccessException e) {
+                // Ignore Timeout Exception. Already treated in the next if statement.
                 componentHealthReport = null;
             }
 
-            if (componentHealthReport != null && componentHealthReport.isHealthy()) {
-                registryWebService.updateAvailabilityStatus(registeredComponent.getId(), ComponentAvailability.ONLINE);
+            boolean isComponentHealthy;
+
+            if (registeredComponent.getComponentType() == ComponentType.UI) {
+                isComponentHealthy = componentHealthReport != null && componentHealthReport.getStatusCode() == HttpStatus.OK;
             } else {
-
-                long lastTimeHealthyTimestamp = registeredComponent.getComponentAvailability().getLastTimeOnline();
-
-                if (registeredComponent.getComponentAvailability().getAvailability() == ComponentAvailability.OFFLINE) {
-                    return;
-                }
-
-                if (System.currentTimeMillis() - lastTimeHealthyTimestamp > availabilityOfflineTimeout) {
-                    registryWebService.updateAvailabilityStatus(registeredComponent.getId(), ComponentAvailability.OFFLINE);
-                    log.warn(String.format("Component %s (%s) did not respond for 1 minute - Marked as Offline.", registeredComponent.getComponentName(), registeredComponent.getId()));
-                } else {
-                    registryWebService.updateAvailabilityStatus(registeredComponent.getId(), ComponentAvailability.NOT_RESPONDING);
-                    log.warn(String.format("Component %s (%s) is not responding.", registeredComponent.getComponentName(), registeredComponent.getId()));
-                }
-
+                isComponentHealthy = componentHealthReport != null && componentHealthReport.getStatusCode() == HttpStatus.OK && componentHealthReport.getBody() != null && componentHealthReport.getBody().isHealthy();
             }
 
+            updateComponentStatus(registeredComponent, isComponentHealthy);
+
         });
+
+    }
+
+    private void updateComponentStatus(RegisteredComponentDto registeredComponent, boolean isHealthy) {
+
+        if (isHealthy) {
+            registryWebService.updateAvailabilityStatus(registeredComponent.getId(), ComponentAvailability.ONLINE);
+        } else {
+            long lastTimeHealthyTimestamp = registeredComponent.getComponentAvailability().getLastTimeOnline();
+
+            if (registeredComponent.getComponentAvailability().getAvailability() == ComponentAvailability.OFFLINE) {
+                return;
+            }
+
+            if (System.currentTimeMillis() - lastTimeHealthyTimestamp > availabilityOfflineTimeout) {
+                registryWebService.updateAvailabilityStatus(registeredComponent.getId(), ComponentAvailability.OFFLINE);
+                log.warn(String.format("Component %s (%s) did not respond for 1 minute - Marked as Offline.", registeredComponent.getComponentName(), registeredComponent.getId()));
+            } else {
+                registryWebService.updateAvailabilityStatus(registeredComponent.getId(), ComponentAvailability.NOT_RESPONDING);
+                log.warn(String.format("Component %s (%s) is not responding.", registeredComponent.getComponentName(), registeredComponent.getId()));
+            }
+
+        }
 
     }
 

--- a/src/main/resources/default.properties
+++ b/src/main/resources/default.properties
@@ -18,5 +18,7 @@ keycloak.use-resource-role-mappings = true
 keycloak.bearer-only=true
 
 Services.Cameras.Ids=a30c95b6-073b-4616-9b3d-f5c24304768c, e988df0c-6a23-49e5-a6a2-9b714fbaf4da, 36e25c8c-165a-445a-b062-9b7a16195dd6
+Services.Alarms.Ids=63f2beca-8fcd-47bc-97fc-cdc5116fdf16, ed42d635-0a84-4bd4-9056-d1650df11dad, db276057-2fc8-40f7-a7a2-0fdddbcd3714
+Services.Others.Ids=16e5d718-075f-4ca9-8d24-fcd8693fdeb4, 5926c88b-c88c-467d-bd98-d37bcaa30b71, bb9b9836-dc70-49f0-b91d-8f16f7e81214, 7c80409e-560b-4641-9c9e-65b81e0e8038, 740b4ed6-077a-49f6-af4b-5a1a8228efed, 4431c20c-b87d-4b7f-b3a1-826a97a6e725
 Services.Availability.OfflineTimeout=60000
 Services.Availability.HealthCheck.Delay=10000


### PR DESCRIPTION
### Description:

The UI components should not be required to have a "/health" endpoint and provide Health Reports like the remaining services in the architecture. Before this PR, the Service Registry would only mark a service as "Online" if the service replied with a Health Report. After this PR, if the service is a UI, then the Service Registry will only require an HTTP.OK status code to mark the service as online.

### What changed?
* Added an extra case for UIs in the ComponentsHealthScheduler class.

### How was it tested?
Tested manually and covered by unit tests. Regression testing to ensure nothing was broken.

### Documentation

https://github.com/ES-22-23/Documentation