### PR TITLE
Fix: HTTP errors throwing exception instead of marking service as Offline

### DIFF
--- a/src/main/java/pt/ua/deti/es/serviceregistry/schedulers/ComponentsHealthScheduler.java
+++ b/src/main/java/pt/ua/deti/es/serviceregistry/schedulers/ComponentsHealthScheduler.java
@@ -12,6 +12,7 @@ import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.client.UnknownContentTypeException;
@@ -60,10 +61,14 @@ public class ComponentsHealthScheduler {
             try {
                 componentHealthReport = restTemplate.exchange(componentHealthEndpoint, HttpMethod.GET, null, HealthReport.class);
             } catch (ResourceAccessException e) {
-                // Ignore Timeout and Failed to Convert to Health Report Exceptions. Already treated in the next if statement.
+                // Ignore Timeout. Already treated in the next if statement.
                 componentHealthReport = null;
             } catch (UnknownContentTypeException e) {
+                // Ignore Unknown Content Type Exception.
                 componentHealthReport = new ResponseEntity<>(null, HttpStatus.valueOf(e.getRawStatusCode()));
+            } catch (HttpServerErrorException e) {
+                // Ignore Server Error Exception.
+                componentHealthReport = new ResponseEntity<>(null, e.getStatusCode());
             }
 
             boolean isComponentHealthy;


### PR DESCRIPTION
### Description:
If the UI component we are trying to ping returns a server error (5XX errors) then an exception is raised interrupting the logic and not marking the service as offline as it should.

### What changed?
* Added an extra catch clause to catch Server errors (5XX errors) and create a Response Entity with that error instead of raising an exception.

### How was it tested?
Tested manually and covered by unit tests. Regression testing to ensure nothing was broken.

### Documentation
https://github.com/ES-22-23/Documentation